### PR TITLE
[PR][#6] 개발 서버 배포 파이프라인 구성

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+Dockerfile
+.dockerignore
+node_modules
+npm-debug.log
+dist

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,0 +1,59 @@
+name: ci-dev
+
+on:
+  push:
+    branches:
+      - 'main'
+jobs:
+  docker-build-and-push:
+    environment: dev
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: create dotenv
+        run: |
+          touch ./.env
+          echo "DATABASE_URL=${{ secrets.DATABASE_URL }}" >> ./.env
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ secrets.REGISTRY_HOST }}
+          username: ${{ secrets.REGISTRY_ID }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          platforms: linux/arm64
+          tags: ${{ secrets.REGISTRY_HOST }}/studium-server:latest
+  docker-pull-and-restart:
+    environment: dev
+    runs-on: ubuntu-latest
+    needs: docker-build-and-push
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: create ansible secrets
+        run: |
+          touch ./ansible/secrets.yml
+          echo "user: '${{ secrets.ANSIBLE_USER }}'" >> ./ansible/secrets.yml
+          echo "registry_host: '${{ secrets.REGISTRY_HOST }}'" >> ./ansible/secrets.yml
+          echo "registry_user: '${{ secrets.REGISTRY_ID }}'" >> ./ansible/secrets.yml
+          echo "registry_password: '${{ secrets.REGISTRY_PASSWORD }}'" >> ./ansible/secrets.yml
+      - name: Run Playbook
+        uses: dawidd6/action-ansible-playbook@v2
+        with:
+          playbook: deploy-playbook.yml
+          directory: ./ansible
+          key: ${{secrets.SSH_PRIVATE_KEY}}
+          inventory: ${{secrets.ANSIBLE_INVENTORY}}

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ lerna-debug.log*
 !.vscode/extensions.json
 
 .env
+/ansible/secrets.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Base image
+FROM node:18-alpine
+
+# Create app directory
+WORKDIR /usr/src/app
+
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+COPY package*.json ./
+
+# Install app dependencies
+RUN npm install
+
+# Bundle app source
+COPY . .
+
+# Creates a "dist" folder with the production build
+RUN npm run build
+
+# Start the server using the production build
+CMD [ "node", "dist/main.js" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,70 @@
+###################
+# BUILD FOR LOCAL DEVELOPMENT
+###################
+
 # Base image
-FROM node:18-alpine
+FROM node:18-alpine AS development
 
 # Create app directory
 WORKDIR /usr/src/app
 
 # A wildcard is used to ensure both package.json AND package-lock.json are copied
-COPY package*.json ./
+COPY --chown=node:node package*.json ./
 
 # Copy env file
-COPY .env ./
+COPY --chown=node:node .env ./
 
 # Install app dependencies
-RUN npm install
+RUN npm ci
 
 # Bundle app source
-COPY . .
+COPY --chown=node:node . .
 
-# Creates a "dist" folder with the production build
+USER node
+
+###################
+# BUILD FOR PRODUCTION
+###################
+
+FROM node:18-alpine As build
+
+# Create app directory
+WORKDIR /usr/src/app
+
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+COPY --chown=node:node package*.json ./
+
+# Copy env file
+COPY --chown=node:node .env ./
+
+# In order to run `npm run build` we need access to the Nest CLI which is a dev dependency. In the previous development stage we ran `npm ci` which installed all dependencies, so we can copy over the node_modules directory from the development image
+COPY --chown=node:node --from=development /usr/src/app/node_modules ./node_modules
+
+COPY --chown=node:node . .
+
+# Run the build command which creates the production bundle
 RUN npx prisma generate
 RUN npm run build
 
+# Set NODE_ENV environment variable
+ENV NODE_ENV production
+
+# Running `npm ci` removes the existing node_modules directory and passing in --only=production ensures that only the production dependencies are installed. This ensures that the node_modules directory is as optimized as possible
+RUN npm ci --only=production && npm cache clean --force
+
+USER node
+
+###################
+# PRODUCTION
+###################
+
+FROM node:18-alpine As production
+
+# Copy the bundled code from the build stage to the production image
+COPY --chown=node:node --from=build /usr/src/app/node_modules ./node_modules
+COPY --chown=node:node --from=build /usr/src/app/dist ./dist
+COPY --chown=node:node --from=build /usr/src/app/.env ./
+
 # Start the server using the production build
 CMD [ "node", "dist/main.js" ]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ WORKDIR /usr/src/app
 # A wildcard is used to ensure both package.json AND package-lock.json are copied
 COPY package*.json ./
 
+# Copy env file
+COPY .env ./
+
 # Install app dependencies
 RUN npm install
 
@@ -14,6 +17,7 @@ RUN npm install
 COPY . .
 
 # Creates a "dist" folder with the production build
+RUN npx prisma generate
 RUN npm run build
 
 # Start the server using the production build

--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ Nest is an MIT-licensed open source project. It can grow thanks to the sponsors 
 - Website - [https://nestjs.com](https://nestjs.com/)
 - Twitter - [@nestframework](https://twitter.com/nestframework)
 
+## Referenced Article for Dockerfile
+
+- https://www.tomray.dev/nestjs-docker-production
+
 ## License
 
 Nest is [MIT licensed](LICENSE).

--- a/ansible/deploy-playbook.yml
+++ b/ansible/deploy-playbook.yml
@@ -12,13 +12,13 @@
         reauthorize: yes
     - name: Pull Docker Image
       become: True
-      shell: /usr/local/bin/docker compose pull leg3nd-agora
+      shell: /usr/local/bin/docker compose pull studium-server
       args:
         chdir: /Users/{{ user }}/Server
         executable: /bin/zsh
     - name: Restart Container
       become: True
-      shell: /usr/local/bin/docker compose up -d leg3nd-agora --force-recreate
+      shell: /usr/local/bin/docker compose up -d studium-server --force-recreate
       args:
         chdir: /Users/{{ user }}/Server
         executable: /bin/zsh

--- a/ansible/deploy-playbook.yml
+++ b/ansible/deploy-playbook.yml
@@ -1,0 +1,24 @@
+- hosts: all
+  vars_files:
+    - secrets.yml
+  remote_user: "{{ user }}"
+  become_user: "{{ user }}"
+  tasks:
+    - name: Log into private registry and force re-authorization
+      docker_login:
+        registry: "{{ registry_host }}"
+        username: "{{ registry_user }}"
+        password: "{{ registry_password }}"
+        reauthorize: yes
+    - name: Pull Docker Image
+      become: True
+      shell: /usr/local/bin/docker compose pull leg3nd-agora
+      args:
+        chdir: /Users/{{ user }}/Server
+        executable: /bin/zsh
+    - name: Restart Container
+      become: True
+      shell: /usr/local/bin/docker compose up -d leg3nd-agora --force-recreate
+      args:
+        chdir: /Users/{{ user }}/Server
+        executable: /bin/zsh

--- a/ansible/secrets.example.yml
+++ b/ansible/secrets.example.yml
@@ -1,0 +1,5 @@
+---
+user: "example"
+registry_host: "example"
+registry_user: "example"
+registry_password: "password"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,18 @@
 services:
+  app:
+    build:
+      dockerfile: Dockerfile
+      context: .
+      # Only will build development stage from our dockerfile
+      target: development
+    volumes:
+      - .:/usr/src/app
+    env_file:
+      - .env
+    # Run a command against the development stage of the image
+    command: sh -c "npx prisma generate && npm run start:dev"
+    ports:
+      - 3000:3000
   postgres:
     image: postgres
     restart: always


### PR DESCRIPTION
# Contents
- #6 관련 PR입니다.
- 광교에 있는 맥미니 (앞으론 mac mini gg (gwang-gyo) 라고 부르겠습니다.)로 배포할 수 있는 간단한 파이프라인을 구성했습니다.
- Ansible과 GitHub Actions를 활용했습니다.
  - Ansible은 사실 이렇게 쓰라고 있는 물건은 아니지만, SSH 대용입니다.
  - GitHub Actions에서 파이프라인을 수행합니다.
- 추후 필요하다면 Test 실행 등을 CI에 추가할 수 있을 듯 합니다.
- `Dockerfile`을 이미지 사이즈를 경량화 할 수 있게 구성했습니다.