### PR TITLE
[PR][#26] User module Response Dto 생성

### DIFF
--- a/src/user/dto/create-user-response.dto.ts
+++ b/src/user/dto/create-user-response.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNumber, IsString, IsDate } from 'class-validator';
+
+export class CreateUserResponseDto{
+    @ApiProperty()
+    @IsNumber()
+    readonly id: number;
+
+    @ApiProperty()
+    @IsDate()
+    readonly createdAt: Date;
+
+    @ApiProperty()
+    @IsNumber()
+    readonly manners: number;
+
+    @ApiProperty()
+    @IsString()
+    readonly intro: string;
+
+    @ApiProperty()
+    @IsString()
+    readonly profileURL: string;
+}

--- a/src/user/dto/get-user-response.dto.ts
+++ b/src/user/dto/get-user-response.dto.ts
@@ -1,23 +1,14 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsOptional, IsNumber, IsString } from 'class-validator';
+import { IsNumber, IsString } from 'class-validator';
 
-
-export class CreateUserDto{
-    @IsOptional()
+export class GetUserResponseDto{
     @ApiProperty()
-    readonly studyJoined;
+    @IsNumber()
+    readonly id: number;
 
     @ApiProperty()
     @IsNumber()
     readonly manners: number;
-
-    @IsOptional()
-    @ApiProperty()
-    readonly membersof;
-
-    @IsOptional()
-    @ApiProperty()
-    readonly applyForms;
 
     @ApiProperty()
     @IsString()

--- a/src/user/dto/update-user-response.dto.ts
+++ b/src/user/dto/update-user-response.dto.ts
@@ -1,0 +1,36 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNumber, IsString, IsDate } from 'class-validator';
+import { Study, ApplyForm, Member } from '@prisma/client';
+
+export class UpdateUserResponseDto{
+    @ApiProperty()
+    @IsNumber()
+    readonly id: number;
+
+    @ApiProperty()
+    @IsDate()
+    readonly updatedAt: Date;
+
+    // todo db task
+    // @ApiProperty()
+    // readonly studyJoined: Study[];
+
+    @ApiProperty()
+    @IsNumber()
+    readonly manners: number;
+
+    // @ApiProperty()
+    // readonly membersof: Member[];
+
+    // @ApiProperty()
+    // readonly applyForms: ApplyForm[];
+
+    
+    @ApiProperty()
+    @IsString()
+    readonly intro: string;
+
+    @ApiProperty()
+    @IsString()
+    readonly profileURL: string;
+}

--- a/src/user/dto/update-user.dto.ts
+++ b/src/user/dto/update-user.dto.ts
@@ -2,7 +2,6 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsOptional, IsNumber, IsString } from 'class-validator';
 
 export class UpdateUserDto{
-    // todo study, member, applyFroms entitys
     @IsOptional()
     @ApiProperty()
     readonly studyJoined;

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Post, Patch, Delete, Param } from '@nestjs/common';
+import { Body, Controller, Get, Post, Patch, Delete, Param, HttpCode } from '@nestjs/common';
 import { UserService } from './user.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
@@ -28,6 +28,7 @@ export class UserController {
     }
 
     @Delete(':id')
+    @HttpCode(204)
     remove(@Param('id') id: string) {
         return this.userService.remove(+id);
     }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,46 +1,68 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaService } from 'src/database/prisma.service';
+import { User } from '@prisma/client';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
+import { GetUserResponseDto } from './dto/get-user-response.dto';
+import { CreateUserResponseDto } from './dto/create-user-response.dto';
+import { UpdateUserResponseDto } from './dto/update-user-response.dto';
 
 @Injectable()
 export class UserService {
     constructor(private prisma: PrismaService) {}
 
-    async findAll() {
-        return await this.prisma.user.findMany();
-    }
+    async findAll(): Promise<GetUserResponseDto[]> {
+        const users: User[] = await this.prisma.user.findMany();
+        const responseUsers = [];
 
-    async findOne(id: number) {
-        const user = await this.prisma.user.findUnique({
-            where: { id },
+        users.forEach((user) => {
+            const {id, manners, intro, profileURL}: GetUserResponseDto = user;
+            responseUsers.push({ id, manners, intro, profileURL });
         });
-        if (!user) {
-            throw new NotFoundException(`User with ID: ${id} not Found.`);
-        }
-        return user;
+
+        return responseUsers;
     }
 
-    async create(createUserDto: CreateUserDto) {
-        return await this.prisma.user.create({
+    async findOne(userId: number): Promise<GetUserResponseDto>{
+        const user: User = await this.prisma.user.findUnique({
+            where: { id: userId },
+        });
+
+        if (!user) {
+            throw new NotFoundException(`User with ID: ${userId} not Found.`);
+        } 
+
+        const { id, manners, intro, profileURL }: GetUserResponseDto = user;
+        return { id, manners, intro, profileURL };
+    }
+
+    async create(createUserDto: CreateUserDto): Promise<CreateUserResponseDto> {
+        const user: User = await this.prisma.user.create({
             data: {
                 ...createUserDto,
             },
         });
+
+        const { id, createdAt, manners, intro, profileURL }: CreateUserResponseDto = user;
+        return { id, createdAt, manners, intro, profileURL };
     }
 
-    async update(id: number, updateUserDto: UpdateUserDto) {
-        const user = await this.findOne(id);
-        return await this.prisma.user.update({
-            where: { id: user['id'] },
+    async update(userId: number, updateUserDto: UpdateUserDto): Promise<UpdateUserResponseDto> {
+        const getUser: GetUserResponseDto = await this.findOne(userId);
+        const user: User = await this.prisma.user.update({
+            where: { id: getUser['id'] },
             data: updateUserDto,
         });
+
+        const { id, updatedAt, manners, intro, profileURL }: UpdateUserResponseDto = user;
+        return { id, updatedAt, manners, intro, profileURL };
     }
 
-    async remove(id: number) {
+    async remove(id: number): Promise<void> {
         const user = await this.findOne(id);
-        return await this.prisma.user.delete({
+        await this.prisma.user.delete({
             where: { id: user['id'] },
         });
+        return;
     }
 }


### PR DESCRIPTION
User Response Dto를 생성합니다.

+ get-user-response
+ create-user-response
+ update-user-response

prisma/client 에서 model type을 가져올 수 있습니다. prismaService를 repository Layer로 활용합니다.

이제 Delete 요청에서 204 (no content)를 반환합니다.

현재 DB User table에 Study, Member, ApplyForm이 반영되어 있지 않아 관련 코드는 주석 처리 했습니다.