### PR TITLE
[PR][#29] DB User model에 통합 계정 아이디 필드 추가

### DIFF
--- a/src/database/migrations/20230713053712_add_universal_account_id/migration.sql
+++ b/src/database/migrations/20230713053712_add_universal_account_id/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `universalAccountId` to the `User` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "universalAccountId" INTEGER NOT NULL;

--- a/src/database/schema.prisma
+++ b/src/database/schema.prisma
@@ -34,15 +34,16 @@ model Study {
 }
 
 model User {
-  id          Int         @id @default(autoincrement())
-  createdAt   DateTime    @default(now())
-  updatedAt   DateTime    @updatedAt
-  manners     Int
-  intro       String
-  profileURL  String
-  applyForms  ApplyForm[]
-  membersOf   Member[]
-  studyJoined Study[]
+  id                  Int         @id @default(autoincrement())
+  createdAt           DateTime    @default(now())
+  updatedAt           DateTime    @updatedAt
+  universalAccountId  Int
+  manners             Int
+  intro               String
+  profileURL          String
+  applyForms          ApplyForm[]
+  membersOf           Member[]
+  studyJoined         Study[]
 }
 
 model Member {

--- a/src/user/dto/create-user.dto.ts
+++ b/src/user/dto/create-user.dto.ts
@@ -3,6 +3,10 @@ import { IsOptional, IsNumber, IsString } from 'class-validator';
 
 
 export class CreateUserDto{
+    @ApiProperty()
+    @IsNumber()
+    readonly universalAccountId: number;
+
     @IsOptional()
     @ApiProperty()
     readonly studyJoined;

--- a/src/user/dto/update-user.dto.ts
+++ b/src/user/dto/update-user.dto.ts
@@ -20,10 +20,12 @@ export class UpdateUserDto{
     readonly applyForms;
 
     
+    @IsOptional()
     @ApiProperty()
     @IsString()
     readonly intro: string;
 
+    @IsOptional()
     @ApiProperty()
     @IsString()
     readonly profileURL: string;


### PR DESCRIPTION
팀 Leg3nd 계정 호환을 위한 필드를 추가했습니다.

<b>model User</b>
+ 컬럼 추가 universalAccountId : number

<b>PATCH DTO 수정</b>
+ update-user.dto의 intro, profileURL 속성에 @IsOpitonal()을 추가했습니다.

<b>POST DTO 수정</b>
+ create-user.dto에 universalAccountId 컬럼을 추가했습니다.
