### PR TITLE
[PR][#46] User response dto에 생성자 추가

### DIFF
--- a/src/database/migrations/20230808012207_set_universal_account_id_to_string_from_int/migration.sql
+++ b/src/database/migrations/20230808012207_set_universal_account_id_to_string_from_int/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ALTER COLUMN "universalAccountId" SET DATA TYPE TEXT;

--- a/src/database/schema.prisma
+++ b/src/database/schema.prisma
@@ -36,7 +36,7 @@ model User {
   id                 Int         @id @default(autoincrement())
   createdAt          DateTime    @default(now())
   updatedAt          DateTime    @updatedAt
-  universalAccountId Int         @unique
+  universalAccountId String      @unique
   manners            Int
   intro              String
   profileURL         String

--- a/src/internal-user/dto/i-get-user-response.dto.ts
+++ b/src/internal-user/dto/i-get-user-response.dto.ts
@@ -15,8 +15,8 @@ export class InternalGetUserResponseDto{
     readonly updatedAt: Date;
     
     @ApiProperty()
-    @IsNumber()
-    readonly universalAccountId: number;
+    @IsString()
+    readonly universalAccountId: string;
 
     @ApiProperty()
     @IsNumber()

--- a/src/user/dto/create-user-response.dto.ts
+++ b/src/user/dto/create-user-response.dto.ts
@@ -21,4 +21,9 @@ export class CreateUserResponseDto{
     @ApiProperty()
     @IsString()
     readonly profileURL: string;
+    
+    constructor(partial: Partial<CreateUserResponseDto>) {
+        Object.assign(this, partial);
+    }
+    
 }

--- a/src/user/dto/create-user-response.dto.ts
+++ b/src/user/dto/create-user-response.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { User } from '@prisma/client';
 import { IsNumber, IsString, IsDate } from 'class-validator';
 
 export class CreateUserResponseDto {
@@ -22,7 +23,11 @@ export class CreateUserResponseDto {
     @IsString()
     readonly profileURL: string;
 
-    constructor(partial: Partial<CreateUserResponseDto>) {
-        Object.assign(this, partial);
+    constructor(user: User) {
+        this.id = user.id;
+        this.createdAt = user.createdAt;
+        this.manners = user.manners;
+        this.intro = user.intro;
+        this.profileURL = user.profileURL;
     }
 }

--- a/src/user/dto/create-user-response.dto.ts
+++ b/src/user/dto/create-user-response.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNumber, IsString, IsDate } from 'class-validator';
 
-export class CreateUserResponseDto{
+export class CreateUserResponseDto {
     @ApiProperty()
     @IsNumber()
     readonly id: number;
@@ -21,9 +21,8 @@ export class CreateUserResponseDto{
     @ApiProperty()
     @IsString()
     readonly profileURL: string;
-    
+
     constructor(partial: Partial<CreateUserResponseDto>) {
         Object.assign(this, partial);
     }
-    
 }

--- a/src/user/dto/create-user.dto.ts
+++ b/src/user/dto/create-user.dto.ts
@@ -2,7 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsOptional, IsNumber, IsString } from 'class-validator';
 
 
-export class CreateUserDto{
+export class CreateUserDto {
     @ApiProperty()
     @IsNumber()
     readonly universalAccountId: number;

--- a/src/user/dto/create-user.dto.ts
+++ b/src/user/dto/create-user.dto.ts
@@ -1,27 +1,14 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsOptional, IsNumber, IsString } from 'class-validator';
-
+import { IsNumber, IsString } from 'class-validator';
 
 export class CreateUserDto {
     @ApiProperty()
-    @IsNumber()
-    readonly universalAccountId: number;
-
-    @IsOptional()
-    @ApiProperty()
-    readonly studyJoined;
+    @IsString()
+    readonly universalAccountId: string;
 
     @ApiProperty()
     @IsNumber()
     readonly manners: number;
-
-    @IsOptional()
-    @ApiProperty()
-    readonly membersof;
-
-    @IsOptional()
-    @ApiProperty()
-    readonly applyForms;
 
     @ApiProperty()
     @IsString()

--- a/src/user/dto/get-user-response.dto.ts
+++ b/src/user/dto/get-user-response.dto.ts
@@ -17,4 +17,8 @@ export class GetUserResponseDto{
     @ApiProperty()
     @IsString()
     readonly profileURL: string;
+
+    constructor(partial: Partial<GetUserResponseDto>) {
+        Object.assign(this, partial);
+    }
 }

--- a/src/user/dto/get-user-response.dto.ts
+++ b/src/user/dto/get-user-response.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNumber, IsString } from 'class-validator';
+import { User } from '@prisma/client';
 
 export class GetUserResponseDto {
     @ApiProperty()
@@ -18,7 +19,10 @@ export class GetUserResponseDto {
     @IsString()
     readonly profileURL: string;
 
-    constructor(partial: Partial<GetUserResponseDto>) {
-        Object.assign(this, partial);
+    constructor(user: User) {
+        this.id = user.id;
+        this.manners = user.manners;
+        this.intro = user.intro;
+        this.profileURL = user.profileURL;
     }
 }

--- a/src/user/dto/get-user-response.dto.ts
+++ b/src/user/dto/get-user-response.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNumber, IsString } from 'class-validator';
 
-export class GetUserResponseDto{
+export class GetUserResponseDto {
     @ApiProperty()
     @IsNumber()
     readonly id: number;

--- a/src/user/dto/update-user-response.dto.ts
+++ b/src/user/dto/update-user-response.dto.ts
@@ -1,5 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { User } from '@prisma/client';
 import { IsNumber, IsString, IsDate } from 'class-validator';
+import { UpdateUserDto } from './update-user.dto';
 
 export class UpdateUserResponseDto {
     @ApiProperty()
@@ -22,7 +24,11 @@ export class UpdateUserResponseDto {
     @IsString()
     readonly profileURL: string;
 
-    constructor(partial: Partial<UpdateUserResponseDto>) {
-        Object.assign(this, partial);
+    constructor(user: User) {
+        this.id = user.id;
+        this.updatedAt = user.updatedAt;
+        this.manners = user.manners;
+        this.intro = user.intro;
+        this.profileURL = user.profileURL;
     }
 }

--- a/src/user/dto/update-user-response.dto.ts
+++ b/src/user/dto/update-user-response.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNumber, IsString, IsDate } from 'class-validator';
 
-export class UpdateUserResponseDto{
+export class UpdateUserResponseDto {
     @ApiProperty()
     @IsNumber()
     readonly id: number;
@@ -21,7 +21,7 @@ export class UpdateUserResponseDto{
     @ApiProperty()
     @IsString()
     readonly profileURL: string;
-    
+
     constructor(partial: Partial<UpdateUserResponseDto>) {
         Object.assign(this, partial);
     }

--- a/src/user/dto/update-user-response.dto.ts
+++ b/src/user/dto/update-user-response.dto.ts
@@ -1,6 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNumber, IsString, IsDate } from 'class-validator';
-import { Study, ApplyForm, Member } from '@prisma/client';
 
 export class UpdateUserResponseDto{
     @ApiProperty()
@@ -11,20 +10,9 @@ export class UpdateUserResponseDto{
     @IsDate()
     readonly updatedAt: Date;
 
-    // todo db task
-    // @ApiProperty()
-    // readonly studyJoined: Study[];
-
     @ApiProperty()
     @IsNumber()
     readonly manners: number;
-
-    // @ApiProperty()
-    // readonly membersof: Member[];
-
-    // @ApiProperty()
-    // readonly applyForms: ApplyForm[];
-
     
     @ApiProperty()
     @IsString()
@@ -33,4 +21,8 @@ export class UpdateUserResponseDto{
     @ApiProperty()
     @IsString()
     readonly profileURL: string;
+    
+    constructor(partial: Partial<UpdateUserResponseDto>) {
+        Object.assign(this, partial);
+    }
 }

--- a/src/user/dto/update-user.dto.ts
+++ b/src/user/dto/update-user.dto.ts
@@ -4,22 +4,9 @@ import { IsOptional, IsNumber, IsString } from 'class-validator';
 export class UpdateUserDto {
     @IsOptional()
     @ApiProperty()
-    readonly studyJoined;
-
-    @IsOptional()
-    @ApiProperty()
     @IsNumber()
     readonly manners: number;
 
-    @IsOptional()
-    @ApiProperty()
-    readonly membersof;
-
-    @IsOptional()
-    @ApiProperty()
-    readonly applyForms;
-
-    
     @IsOptional()
     @ApiProperty()
     @IsString()

--- a/src/user/dto/update-user.dto.ts
+++ b/src/user/dto/update-user.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsOptional, IsNumber, IsString } from 'class-validator';
 
-export class UpdateUserDto{
+export class UpdateUserDto {
     @IsOptional()
     @ApiProperty()
     readonly studyJoined;

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -12,14 +12,9 @@ export class UserService {
   constructor(private prisma: PrismaService) {}
 
     async findAll(): Promise<GetUserResponseDto[]> {
-        const users: User[] = await this.prisma.user.findMany();
-        const responseUsers = users.map((user) => {
-            const { id, manners, intro, profileURL }: GetUserResponseDto = user;
-            return { id, manners, intro, profileURL };
-        });
-
-      return responseUsers;
-  }
+        const users: User[] = await this.prisma.user.findMany();  
+        return users.map((user) => { return new GetUserResponseDto(user); });
+    }
 
     async findOne(userId: number): Promise<GetUserResponseDto>{
         if (isNaN(userId)) {
@@ -34,8 +29,7 @@ export class UserService {
             throw new InternalServerErrorException(`User with ID: ${userId} not Found.`);
         } 
 
-      const { id, manners, intro, profileURL }: GetUserResponseDto = user;
-      return { id, manners, intro, profileURL };
+      return new GetUserResponseDto(user);
     }
 
   async create(createUserDto: CreateUserDto): Promise<CreateUserResponseDto> {
@@ -45,19 +39,17 @@ export class UserService {
           },
       });
 
-      const { id, createdAt, manners, intro, profileURL }: CreateUserResponseDto = user;
-      return { id, createdAt, manners, intro, profileURL };
+      return new CreateUserResponseDto(user);
   }
 
   async update(userId: number, updateUserDto: UpdateUserDto): Promise<UpdateUserResponseDto> {
-      const getUser: GetUserResponseDto = await this.findOne(userId);
-      const user: User = await this.prisma.user.update({
-          where: { id: getUser['id'] },
+      const user: GetUserResponseDto = await this.findOne(userId);
+      const updatedUser: User = await this.prisma.user.update({
+          where: { id: user['id'] },
           data: updateUserDto,
       });
 
-      const { id, updatedAt, manners, intro, profileURL }: UpdateUserResponseDto = user;
-      return { id, updatedAt, manners, intro, profileURL };
+      return new UpdateUserResponseDto(updatedUser);
   }
 
   async remove(id: number): Promise<void> {


### PR DESCRIPTION
- 불필요한 주석을 지웠습니다.
- universal-account-id 값을 string으로 변경했습니다.
- User Dto 내에 연관 테이블 인자를 삭제했습니다. 
- 이제 생성자를 통해 값을 반환합니다. (DTO 형태로 적용됩니다.)


![image](https://github.com/TEAM-LEG3ND/studium-server/assets/29320054/97b1ad1a-6c69-4c89-a9b3-34a3854a89f0)

![image](https://github.com/TEAM-LEG3ND/studium-server/assets/29320054/d7ff1a33-04b3-4243-a7db-b40ef524fd0f)
![image](https://github.com/TEAM-LEG3ND/studium-server/assets/29320054/6d0ef900-869b-4f9f-9d24-d61f07185cf4)
