### PR TITLE
[PR][#48] 인기 스터디 조회 API

### DIFF
--- a/src/database/migrations/20230817030435_add_view_count_on_study/migration.sql
+++ b/src/database/migrations/20230817030435_add_view_count_on_study/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Study" ADD COLUMN     "viewCount" INTEGER NOT NULL DEFAULT 0;

--- a/src/database/schema.prisma
+++ b/src/database/schema.prisma
@@ -25,6 +25,7 @@ model Study {
   recruited        Int
   total            Int
   templateContent  String
+  viewCount        Int         @default(0)
   member           Member[]
   leader           User        @relation(fields: [leaderId], references: [id])
   tags             Tag[]       @relation("StudyToTag")

--- a/src/study/dto/create-study-response.dto.ts
+++ b/src/study/dto/create-study-response.dto.ts
@@ -56,6 +56,10 @@ export class CreateStudyResponseDto {
   @IsString()
   readonly templateContent: string;
 
+  @ApiProperty({ required: false })
+  @IsNumber()
+  readonly viewCount: number;
+
   @ApiProperty({ type: [CreateTagDto], default: [] })
   readonly tags: CreateTagDto[];
 
@@ -81,6 +85,7 @@ export class CreateStudyResponseDto {
     total: number,
     recruited: number,
     templateContent: string,
+    viewCount: number,
     tags: CreateTagDto[],
     questions: CreateQuestionDto[],
   ) {
@@ -98,6 +103,7 @@ export class CreateStudyResponseDto {
     this.total = total;
     this.recruited = recruited;
     this.templateContent = templateContent;
+    this.viewCount = viewCount;
     this.tags = tags;
     this.questions = questions;
   }
@@ -119,6 +125,7 @@ export class CreateStudyResponseDto {
       study.total,
       study.recruited,
       study.templateContent,
+      study.viewCount,
       study['tags'],
       study['questions'],
     );

--- a/src/study/dto/create-study.dto.ts
+++ b/src/study/dto/create-study.dto.ts
@@ -50,6 +50,11 @@ export class CreateStudyDto {
   readonly templateContent: string;
 
   @IsOptional()
+  @ApiProperty({ required: false })
+  @IsNumber()
+  readonly viewCount: number;
+
+  @IsOptional()
   @ApiProperty({ type: [String], default: [] })
   readonly tags: string[];
 

--- a/src/study/dto/create-study.dto.ts
+++ b/src/study/dto/create-study.dto.ts
@@ -50,11 +50,6 @@ export class CreateStudyDto {
   readonly templateContent: string;
 
   @IsOptional()
-  @ApiProperty({ required: false })
-  @IsNumber()
-  readonly viewCount: number;
-
-  @IsOptional()
   @ApiProperty({ type: [String], default: [] })
   readonly tags: string[];
 

--- a/src/study/dto/get-study-response.dto.ts
+++ b/src/study/dto/get-study-response.dto.ts
@@ -56,6 +56,10 @@ export class GetStudyResponseDto {
   @IsString()
   readonly templateContent: string;
 
+  @ApiProperty({ required: false })
+  @IsNumber()
+  readonly viewCount: number;
+
   @ApiProperty({ type: [GetTagResponseDto] })
   readonly tags: GetTagResponseDto[];
 
@@ -82,6 +86,7 @@ export class GetStudyResponseDto {
     total: number,
     recruited: number,
     templateContent: string,
+    viewCount: number,
     tags: GetTagResponseDto[],
     questions: GetQuestionResponseDto[],
   ) {
@@ -99,6 +104,7 @@ export class GetStudyResponseDto {
     this.total = total;
     this.recruited = recruited;
     this.templateContent = templateContent;
+    this.viewCount = viewCount;
     this.tags = tags;
     this.questions = questions;
   }
@@ -120,6 +126,7 @@ export class GetStudyResponseDto {
       study.total,
       study.recruited,
       study.templateContent,
+      study.viewCount,
       study['tags'],
       study['questions'],
     );

--- a/src/study/dto/update-study-response.dto.ts
+++ b/src/study/dto/update-study-response.dto.ts
@@ -2,7 +2,6 @@ import { CreateTagDto } from 'src/tag/dto/create-tag.dto';
 import { CreateStudyResponseDto } from './create-study-response.dto';
 import { Study } from '@prisma/client';
 import { Location, getLocationEnumValue } from './enums';
-import { CreateQuestionDto } from 'src/question/dto/create-question.dto';
 import { GetQuestionResponseDto } from 'src/question/dto/get-question-response.dto';
 
 export class UpdateStudyResponseDto extends CreateStudyResponseDto {
@@ -25,6 +24,7 @@ export class UpdateStudyResponseDto extends CreateStudyResponseDto {
     total: number,
     recruited: number,
     templateContent: string,
+    viewCount: number,
     tags: CreateTagDto[],
     questions: GetQuestionResponseDto[],
   ) {
@@ -43,6 +43,7 @@ export class UpdateStudyResponseDto extends CreateStudyResponseDto {
       total,
       recruited,
       templateContent,
+      viewCount,
       tags,
       questions,
     );
@@ -65,6 +66,7 @@ export class UpdateStudyResponseDto extends CreateStudyResponseDto {
       study.total,
       study.recruited,
       study.templateContent,
+      study.viewCount,
       study['tags'],
       study['questions'],
     );

--- a/src/study/study.controller.ts
+++ b/src/study/study.controller.ts
@@ -19,6 +19,11 @@ export class StudyController {
   findAll(): Promise<GetStudyResponseDto[]> {
     return this.studyService.findAll();
   }
+  
+  @Get('onfire/')
+  getStudiesOnFire(): Promise<GetStudyResponseDto[]> {
+    return this.studyService.getStudiesOnFire();
+  }
 
   @Get(':id')
   findOne(@Param('id') id: string): Promise<GetStudyResponseDto> {

--- a/src/study/study.controller.ts
+++ b/src/study/study.controller.ts
@@ -20,7 +20,7 @@ export class StudyController {
     return this.studyService.findAll();
   }
 
-  @Get('onfire')
+  @Get('on-fire')
   getStudiesOnFire(): Promise<GetStudyResponseDto[]> {
     return this.studyService.getStudiesOnFire();
   }

--- a/src/study/study.controller.ts
+++ b/src/study/study.controller.ts
@@ -35,6 +35,11 @@ export class StudyController {
     return this.studyService.update(+id, updateStudyDto);
   }
 
+  @Patch(':id/increment-views')
+  incrementViewCount(@Param('id') id:string): Promise<UpdateStudyResponseDto> {
+    return this.studyService.incrementViewCount(+id);
+  } 
+
   @Delete(':id')
   remove(@Param('id') id: string) {
     return this.studyService.remove(+id);

--- a/src/study/study.controller.ts
+++ b/src/study/study.controller.ts
@@ -19,8 +19,8 @@ export class StudyController {
   findAll(): Promise<GetStudyResponseDto[]> {
     return this.studyService.findAll();
   }
-  
-  @Get('onfire/')
+
+  @Get('onfire')
   getStudiesOnFire(): Promise<GetStudyResponseDto[]> {
     return this.studyService.getStudiesOnFire();
   }

--- a/src/study/study.service.ts
+++ b/src/study/study.service.ts
@@ -126,7 +126,7 @@ export class StudyService {
     const THREE_WEEKS_IN_MILLI_SEC = 3 * 7 * 24 * 60 * 60 * 1000;
     const now = new Date();
     const threeWeeksAgo = new Date(now.getTime() - THREE_WEEKS_IN_MILLI_SEC);
-    
+
     const studies = await this.prisma.study.findMany({
       where: {
         createdAt: {
@@ -138,6 +138,10 @@ export class StudyService {
         tags: true,
         questions: true,
       },
+      orderBy: {
+        viewCount: 'desc',
+      },
+      take: 10,
     });
     return studies.map((study) => GetStudyResponseDto.fromStudy(study));
   }

--- a/src/study/study.service.ts
+++ b/src/study/study.service.ts
@@ -145,4 +145,16 @@ export class StudyService {
     });
     return studies.map((study) => GetStudyResponseDto.fromStudy(study));
   }
+
+  async incrementViewCount(id: number): Promise<UpdateStudyResponseDto> {    
+    const study = await this.prisma.study.update({
+      where : { id },
+      data : {
+        viewCount : {
+          increment: 1
+        }
+      },
+    });
+    return UpdateStudyResponseDto.fromStudy(study);
+  }
 }

--- a/src/study/study.service.ts
+++ b/src/study/study.service.ts
@@ -121,4 +121,24 @@ export class StudyService {
     });
     return studies.map((study) => GetStudyResponseDto.fromStudy(study));
   }
+
+  async getStudiesOnFire(): Promise<GetStudyResponseDto[]> {
+    const THREE_WEEKS_IN_MILLI_SEC = 3 * 7 * 24 * 60 * 60 * 1000;
+    const now = new Date();
+    const threeWeeksAgo = new Date(now.getTime() - THREE_WEEKS_IN_MILLI_SEC);
+    
+    const studies = await this.prisma.study.findMany({
+      where: {
+        createdAt: {
+          gte: threeWeeksAgo, // greater than or equal to
+          lte: now            // less than or equal to
+        }
+      },
+      include: {
+        tags: true,
+        questions: true,
+      },
+    });
+    return studies.map((study) => GetStudyResponseDto.fromStudy(study));
+  }
 }

--- a/src/study/study.service.ts
+++ b/src/study/study.service.ts
@@ -141,7 +141,7 @@ export class StudyService {
       orderBy: {
         viewCount: 'desc',
       },
-      take: 10,
+      take: 12,
     });
     return studies.map((study) => GetStudyResponseDto.fromStudy(study));
   }


### PR DESCRIPTION
study 모델에 조회수 항목(viewCount: number)을 추가하였습니다.

+ 인기 스터디 목록을 조회할 수 있습니다.
```
api/v1/study/on-fire/
```

<i>3주 이내에 생성된 조회수 TOP 12 스터디 리스트 리턴 (내림차순)</i>

+ 아래 API로 스터디의 조회수를 증가 시킬 수 있습니다.

```
api/v1/study/{id}/increment-views
```
