### PR TITLE
[feat] API Gateway Auth 적용

### DIFF
--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,12 +1,15 @@
 import { Controller, Get } from '@nestjs/common';
 import { AppService } from './app.service';
+import { UniversalAccountId, UniversalAccountIdHeader } from './common/account/universal-account-id.decorator';
+import { SwaggerUniversalAccountId } from './config/decorator/swagger-universal-account-id.decorator';
 
 @Controller()
 export class AppController {
   constructor(private readonly appService: AppService) {}
 
   @Get()
-  getHello(): string {
-    return this.appService.getHello();
+  @SwaggerUniversalAccountId()
+  getHello(@UniversalAccountIdHeader() accountId: UniversalAccountId): string {
+    return this.appService.getHello(accountId);
   }
 }

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -1,11 +1,12 @@
 import { Inject, Injectable, LoggerService } from '@nestjs/common';
 import { Logger } from '@nestjs/common/services';
+import { UniversalAccountId } from './common/account/universal-account-id.decorator';
 
 @Injectable()
 export class AppService {
   constructor(@Inject(Logger) private readonly logger: LoggerService) {}
 
-  getHello(): string {
-    return 'Hello Studium!';
+  getHello(accountId: UniversalAccountId): string {
+    return `Hello Studium! and Hello user with id ${accountId}`;
   }
 }

--- a/src/common/account/universal-account-id.decorator.ts
+++ b/src/common/account/universal-account-id.decorator.ts
@@ -1,7 +1,11 @@
 import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 
+export type UniversalAccountId = string | null | undefined;
+
 export const X_ACCOUNT_ID_HEADER = 'x-account-id';
 
-export const UniversalAccountId = createParamDecorator((data, ctx: ExecutionContext): string | null | undefined => {
-  return ctx.switchToHttp().getRequest().headers[X_ACCOUNT_ID_HEADER];
-});
+export const UniversalAccountIdHeader = createParamDecorator(
+  (data, ctx: ExecutionContext): string | null | undefined => {
+    return ctx.switchToHttp().getRequest().headers[X_ACCOUNT_ID_HEADER];
+  },
+);

--- a/src/common/account/universal-account-id.decorator.ts
+++ b/src/common/account/universal-account-id.decorator.ts
@@ -1,0 +1,7 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export const X_ACCOUNT_ID_HEADER = 'x-account-id';
+
+export const UniversalAccountId = createParamDecorator((data, ctx: ExecutionContext): string | null | undefined => {
+  return ctx.switchToHttp().getRequest().headers[X_ACCOUNT_ID_HEADER];
+});

--- a/src/config/decorator/swagger-universal-account-id.decorator.ts
+++ b/src/config/decorator/swagger-universal-account-id.decorator.ts
@@ -1,0 +1,12 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiHeader } from '@nestjs/swagger';
+import { X_ACCOUNT_ID_HEADER } from '../../common/account/universal-account-id.decorator';
+
+export function SwaggerUniversalAccountId() {
+  return applyDecorators(
+    ApiHeader({
+      name: X_ACCOUNT_ID_HEADER,
+      description: 'account id from API Gateway',
+    }),
+  );
+}


### PR DESCRIPTION
# Contents
- API Gateway에서 `x-account-id` 라는 헤더를 통해 유저의 ID를 받아올 수 있도록 합니다.
  - 이를 위해 `@UniversalAccountIdHeader()`라는 데코레이터를 구성했습니다.
  - Public Endpoint를 제외하고는 해당 헤더가 필요할텐데, Controller 메서드 위에 `@SwaggerUniversalAccountId()`를 붙여주시면 Swagger에 사진처럼 헤더 입력 칸이 생깁니다.
![스크린샷 2023-09-07 오후 10 38 38](https://github.com/TEAM-LEG3ND/studium-server/assets/23608029/39cd343f-2475-4c1e-ae5b-c456d7df70db)
- 현재 다들 토큰이 없으실텐데요, [여기](https://studium-fe.vercel.app/modaltest)에서 구글 로그인을 완료하시면 계정이 생성되고, 제가 그 계정 기반으로 토큰을 생성해드리도록 하겠습니다.
- 개발하실 때에는 계정 ID를 전달해드릴테니, 해당 계정 ID 기준으로 개발하시면 될 것 같습니다.
  - 데코레이터를 조금 더 발전시켜서, 계정 ID를 기준으로 Studium 유저 ID를 불러올 수 있도록 하면 더 좋겠네요.
  - Studium 유저 회원가입 기능 만드실 분 구합니다. 같이 협업해요.

# Validation
- 로컬 Swagger에서 정상 응답 확인했습니다.
![스크린샷 2023-09-07 오후 10 40 02](https://github.com/TEAM-LEG3ND/studium-server/assets/23608029/4f2c9d7a-2953-4705-b4fe-b5bcb7f36cdd)
