### PR TITLE
[feat] 회원 가입 절차 구현

### DIFF
--- a/src/common/account/universal-account-id.decorator.ts
+++ b/src/common/account/universal-account-id.decorator.ts
@@ -1,11 +1,13 @@
-import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { createParamDecorator, ExecutionContext, UnauthorizedException } from '@nestjs/common';
 
-export type UniversalAccountId = string | null | undefined;
+export type UniversalAccountId = string;
 
 export const X_ACCOUNT_ID_HEADER = 'x-account-id';
 
-export const UniversalAccountIdHeader = createParamDecorator(
-  (data, ctx: ExecutionContext): string | null | undefined => {
-    return ctx.switchToHttp().getRequest().headers[X_ACCOUNT_ID_HEADER];
-  },
-);
+export const UniversalAccountIdHeader = createParamDecorator((data, ctx: ExecutionContext): string => {
+  const xAccountId = ctx.switchToHttp().getRequest().headers[X_ACCOUNT_ID_HEADER];
+  if (xAccountId === undefined || xAccountId === null) {
+    throw new UnauthorizedException('No x-account-id provided');
+  }
+  return xAccountId;
+});

--- a/src/common/warmup/warmup.service.ts
+++ b/src/common/warmup/warmup.service.ts
@@ -10,7 +10,7 @@ export class WarmupService implements OnApplicationBootstrap {
 
   onApplicationBootstrap() {
     const publicEndpoints = ['/test/public'];
-    const draftEndpoints = ['/test/draft'];
+    const draftEndpoints = ['/api/v1/user'];
     const basePath = '/studium';
 
     const requestBody = {

--- a/src/user/dto/create-user.dto.ts
+++ b/src/user/dto/create-user.dto.ts
@@ -2,23 +2,15 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsNumber, IsString } from 'class-validator';
 
 export class CreateUserDto {
-    @ApiProperty()
-    @IsString()
-    readonly nickname: string;
+  @ApiProperty()
+  @IsString()
+  readonly nickname: string;
 
-    @ApiProperty()
-    @IsString()
-    readonly universalAccountId: string;
+  @ApiProperty()
+  @IsString()
+  readonly intro: string;
 
-    @ApiProperty()
-    @IsNumber()
-    readonly manners: number;
-
-    @ApiProperty()
-    @IsString()
-    readonly intro: string;
-
-    @ApiProperty()
-    @IsString()
-    readonly profileURL: string;
+  @ApiProperty()
+  @IsString()
+  readonly profileURL: string;
 }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -4,6 +4,8 @@ import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { ApiBearerAuth } from '@nestjs/swagger';
 import { ACCESS_TOKEN } from '../config/swagger-config';
+import { UniversalAccountId, UniversalAccountIdHeader } from '../common/account/universal-account-id.decorator';
+import { SwaggerUniversalAccountId } from '../config/decorator/swagger-universal-account-id.decorator';
 
 @Controller()
 @ApiBearerAuth(ACCESS_TOKEN)
@@ -26,8 +28,9 @@ export class UserController {
   }
 
   @Post()
-  create(@Body() createUserDto: CreateUserDto) {
-    return this.userService.create(createUserDto);
+  @SwaggerUniversalAccountId()
+  create(@UniversalAccountIdHeader() accountId: UniversalAccountId, @Body() createUserDto: CreateUserDto) {
+    return this.userService.create(accountId, createUserDto);
   }
 
   @Patch(':id')

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { UserController } from './user.controller';
 import { UserService } from './user.service';
 import { PrismaModule } from 'src/database/prisma.module';
+import { HttpModule } from '@nestjs/axios';
 
 @Module({
-  imports: [PrismaModule],
+  imports: [PrismaModule, HttpModule],
   controllers: [UserController],
   providers: [UserService],
 })


### PR DESCRIPTION
# Contents
- 회원 가입 절차를 구현합니다.
- studium server로 요청이 넘어오는 시점에 이미 유저는 draft 상태로 turnstile에 가입이 되어 있는 상태입니다.
- studium user로 가입함을 turnstile에 알려줌으로써, turnstile에서 해당 유저를 studium에 접근 시 인가할 수 있게 합니다.
- warmup 시 회원 가입 api를 draft api 로 전달함으로써 turnstile이 해당 계정이 studium 접근 권한을 가지고 있지 않더라도 회원 가입을 시도할 수 있게 합니다.
- transaction outbox 관련 내용은 구현이 되어 있지 않으나, 현재 단계에서는 크게 필요해 보이진 않습니다.
  - db에 저장한 후 turnstile API를 호출하는 부분까지 transactional로 묶어볼 수 는 있겠습니다.

# Validation
- 로컬 환경에서 호출 후 정상 작동을 확인했습니다.
- 개발 서버에서 정상 작동을 확인할 필요가 있습니다.