### PR TITLE
[PR][#83] Notice가 null일 때, code 500 대신 빈 응답 내리기

### DIFF
--- a/src/study/study.service.ts
+++ b/src/study/study.service.ts
@@ -205,7 +205,9 @@ export class StudyService {
       },
     });
 
-    return GetNoticeResponseDto.fromNotice(notice);
+    if (notice)
+      return GetNoticeResponseDto.fromNotice(notice);
+    return;
   }
 
   async findJournals(id: number): Promise<GetJournalResponseDto[]> {


### PR DESCRIPTION
API : study/{id}/notice 
notice가 없을 때, 응답 값 변경했습니다.
기존 500 Internal server error -> 현재 code 200 빈 응답
![image](https://github.com/TEAM-LEG3ND/studium-server/assets/29320054/c7310e95-29a3-4d99-a332-1cf883d7f8d0)
